### PR TITLE
Fix binary marshal/unmarshal

### DIFF
--- a/binarymarshaler.go
+++ b/binarymarshaler.go
@@ -33,6 +33,8 @@ func (f *Filter) marshal() (buf *bytes.Buffer, hash [sha512.Size384]byte, err er
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
+	debug("write bf k=%d n=%d m=%d\n", f.K(), f.n, f.m)
+
 	buf = new(bytes.Buffer)
 
 	err = binary.Write(buf, binary.LittleEndian, f.K())
@@ -50,11 +52,23 @@ func (f *Filter) marshal() (buf *bytes.Buffer, hash [sha512.Size384]byte, err er
 		return
 	}
 
+	kLen := uint64(len(f.keys))
+	debug("write bf kLen%d", kLen)
+	err = binary.Write(buf, binary.LittleEndian, kLen)
+	if err != nil {
+		return
+	}
 	err = binary.Write(buf, binary.LittleEndian, f.keys)
 	if err != nil {
 		return
 	}
 
+	bLen := uint64(len(f.bits))
+	debug("write bf bLen%d", bLen)
+	err = binary.Write(buf, binary.LittleEndian, bLen)
+	if err != nil {
+		return
+	}
 	err = binary.Write(buf, binary.LittleEndian, f.bits)
 	if err != nil {
 		return
@@ -70,6 +84,8 @@ func (f *Filter) MarshalBinary() (data []byte, err error) {
 	if err != nil {
 		return
 	}
+
+	data = buf.Bytes()
 
 	debug("bloomfilter.MarshalBinary: Successfully wrote %d byte(s), sha384 %v", buf.Len(), hash)
 

--- a/binarymarshaler.go
+++ b/binarymarshaler.go
@@ -52,23 +52,11 @@ func (f *Filter) marshal() (buf *bytes.Buffer, hash [sha512.Size384]byte, err er
 		return
 	}
 
-	kLen := uint64(len(f.keys))
-	debug("write bf kLen%d", kLen)
-	err = binary.Write(buf, binary.LittleEndian, kLen)
-	if err != nil {
-		return
-	}
 	err = binary.Write(buf, binary.LittleEndian, f.keys)
 	if err != nil {
 		return
 	}
 
-	bLen := uint64(len(f.bits))
-	debug("write bf bLen%d", bLen)
-	err = binary.Write(buf, binary.LittleEndian, bLen)
-	if err != nil {
-		return
-	}
 	err = binary.Write(buf, binary.LittleEndian, f.bits)
 	if err != nil {
 		return

--- a/binaryunmarshaler.go
+++ b/binaryunmarshaler.go
@@ -50,24 +50,13 @@ func (f *Filter) UnmarshalBinary(data []byte) (err error) {
 
 	debug("read bf k=%d n=%d m=%d\n", k, f.n, f.m)
 
-	var kLen uint64
-	err = binary.Read(buf, binary.LittleEndian, &kLen)
-	if err != nil {
-		return
-	}
-	f.keys = make([]uint64, kLen)
+	f.keys = make([]uint64, k)
 	err = binary.Read(buf, binary.LittleEndian, f.keys)
 	if err != nil {
 		return
 	}
 
-	var bLen uint64
-	err = binary.Read(buf, binary.LittleEndian, &bLen)
-	if err != nil {
-		return
-	}
-
-	f.bits = make([]uint64, bLen)
+	f.bits = make([]uint64, k.n)
 	err = binary.Read(buf, binary.LittleEndian, f.bits)
 	if err != nil {
 		return

--- a/binaryunmarshaler.go
+++ b/binaryunmarshaler.go
@@ -56,7 +56,7 @@ func (f *Filter) UnmarshalBinary(data []byte) (err error) {
 		return
 	}
 
-	f.bits = make([]uint64, k.n)
+	f.bits = make([]uint64, f.n)
 	err = binary.Read(buf, binary.LittleEndian, f.bits)
 	if err != nil {
 		return

--- a/binaryunmarshaler.go
+++ b/binaryunmarshaler.go
@@ -50,13 +50,24 @@ func (f *Filter) UnmarshalBinary(data []byte) (err error) {
 
 	debug("read bf k=%d n=%d m=%d\n", k, f.n, f.m)
 
-	f.keys = make([]uint64, k)
+	var kLen uint64
+	err = binary.Read(buf, binary.LittleEndian, &kLen)
+	if err != nil {
+		return
+	}
+	f.keys = make([]uint64, kLen)
 	err = binary.Read(buf, binary.LittleEndian, f.keys)
 	if err != nil {
 		return
 	}
 
-	f.bits = make([]uint64, f.n)
+	var bLen uint64
+	err = binary.Read(buf, binary.LittleEndian, &bLen)
+	if err != nil {
+		return
+	}
+
+	f.bits = make([]uint64, bLen)
 	err = binary.Read(buf, binary.LittleEndian, f.bits)
 	if err != nil {
 		return

--- a/fileio.go
+++ b/fileio.go
@@ -33,7 +33,7 @@ func ReadFrom(r io.Reader) (f *Filter, n int64, err error) {
 	}
 	defer rawR.Close()
 
-	content, err := ioutil.ReadAll(r)
+	content, err := ioutil.ReadAll(rawR)
 	if err != nil {
 		return
 	}

--- a/fileio_test.go
+++ b/fileio_test.go
@@ -1,0 +1,30 @@
+package bloomfilter
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteRead(t *testing.T) {
+	// minimal filter
+	f := New(2, 1)
+
+	v := hashableUint64(0)
+	f.Add(v)
+
+	var b bytes.Buffer
+
+	_, err := f.WriteTo(&b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f2, _, err := ReadFrom(&b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !f2.Contains(v) {
+		t.Error("Filters not equal")
+	}
+}


### PR DESCRIPTION
Thanks for a complete library. I fixed some issues I ran into using the marshalling to files feature:
- Using correct raw stream in ReadFrom
- Store length of bits and keys in serialized format
- Add basic test coverage
