### PR TITLE
Fix condition in `Filter.Contains`

### DIFF
--- a/bloomfilter.go
+++ b/bloomfilter.go
@@ -65,11 +65,11 @@ func (f *Filter) Contains(v hash.Hash64) bool {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
-	r := uint64(0)
+	r := uint64(1)
 	for _, i := range f.hash(v) {
 		// r |= f.getBit(k)
 		i %= f.m
-		r |= (f.bits[i>>6] >> uint(i&0x3f)) & 1
+		r &= (f.bits[i>>6] >> uint(i&0x3f)) & 1
 	}
 	return uint64ToBool(r)
 }


### PR DESCRIPTION
By construction of a Bloom filter, _all_ the bit positions of an item must be 1 if the item is in the set. The current code assumes that an item might be in the set if _any_ of its bit positions are 1, ending up in a filter that is still correct but vastly less specific.