### PR TITLE
Fix formula for OptimalM

### DIFF
--- a/optimal.go
+++ b/optimal.go
@@ -24,5 +24,5 @@ func OptimalK(m, maxN uint64) uint64 {
 // p is the desired false positive probability
 // optimal m = ceiling( - n * ln(p) / ln(2)**2 )
 func OptimalM(maxN uint64, p float64) uint64 {
-	return uint64(math.Ceil(-float64(maxN) * math.Log(p) / math.Ln2 * math.Ln2))
+	return uint64(math.Ceil(-float64(maxN) * math.Log(p) / (math.Ln2 * math.Ln2)))
 }

--- a/optimal_test.go
+++ b/optimal_test.go
@@ -1,0 +1,55 @@
+package bloomfilter
+
+import (
+	"testing"
+)
+
+func TestOptimal(t *testing.T) {
+	tests := []struct {
+		n    uint64
+		p    float64
+		k, m uint64
+	}{
+		{
+			n: 1000,
+			p: 0.01 / 100,
+			k: 14,
+			m: 19171,
+		},
+		{
+			n: 10000,
+			p: 0.01 / 100,
+			k: 14,
+			m: 191702,
+		},
+		{
+			n: 10000,
+			p: 0.01 / 100,
+			k: 14,
+			m: 191702,
+		},
+		{
+			n: 1000,
+			p: 0.001 / 100,
+			k: 17,
+			m: 23963,
+		},
+	}
+
+	for _, test := range tests {
+		m := OptimalM(test.n, test.p)
+		k := OptimalK(m, test.n)
+
+		if k != test.k || m != test.m {
+			t.Errorf(
+				"n=%d p=%f: expected (m=%d, k=%d), got (m=%d, k=%d)",
+				test.n,
+				test.p,
+				test.m,
+				test.k,
+				m,
+				k,
+			)
+		}
+	}
+}


### PR DESCRIPTION
As I mentioned in #6, the formula for OptimalM is wrong by a set of parenthesis. This understated the value of K and M, resulting in filters that were significantly less specific than expected.